### PR TITLE
Fix patch function in hook's initialize for Sails v0.12+

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var pagify = require(path.join(libPath, 'pagify'));
 module.exports = function(sails){
 
     function patch(context){
-        _(sails.models).forEach(function(model){
+        _.forEach(sails.models, function(model){
 
             // Add pagify method to all models. Ignoring associative tables
             if(model.globalId){


### PR DESCRIPTION
For some reason the patch function doesn't work on Sails v0.12.1

![sails-hook-pagify-error1](https://cloud.githubusercontent.com/assets/3619844/13847429/13b1516c-ec45-11e5-8d04-60e5ffcccffd.png)
![sails-hook-pagify-error2](https://cloud.githubusercontent.com/assets/3619844/13847437/1ad5b442-ec45-11e5-9cc0-54351508d42f.png)
![sails-hook-pagify-error3](https://cloud.githubusercontent.com/assets/3619844/13847446/1f358d14-ec45-11e5-9130-a7a3a0937b8a.png)
